### PR TITLE
Status route

### DIFF
--- a/cmd/template/framework/files/routes/chi.go.tmpl
+++ b/cmd/template/framework/files/routes/chi.go.tmpl
@@ -20,6 +20,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r.Use(middleware.Logger)
 
 	r.Get("/", s.HelloWorldHandler)
+	r.Get("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	r.Get("/health", s.healthHandler)
   {{end}}
@@ -34,6 +35,18 @@ func (s *Server) RegisterRoutes() http.Handler {
 func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 	resp := make(map[string]string)
 	resp["message"] = "Hello World"
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("error handling JSON marshal. Err: %v", err)
+	}
+
+	_, _ = w.Write(jsonResp)
+}
+
+func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
+	resp := make(map[string]string)
+	resp["status"] = "OK"
 
 	jsonResp, err := json.Marshal(resp)
 	if err != nil {

--- a/cmd/template/framework/files/routes/echo.go.tmpl
+++ b/cmd/template/framework/files/routes/echo.go.tmpl
@@ -19,6 +19,7 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	e.GET("/", s.HelloWorldHandler)
+	e.GET("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	e.GET("/health", s.healthHandler)
   {{end}}
@@ -32,6 +33,14 @@ func (s *Server) RegisterRoutes() http.Handler {
 func (s *Server) HelloWorldHandler(c echo.Context) error {
 	resp := map[string]string{
 		"message": "Hello World",
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (s *Server) statusHandler(c echo.Context) error {
+	resp := map[string]string{
+		"status": "OK",
 	}
 
 	return c.JSON(http.StatusOK, resp)

--- a/cmd/template/framework/files/routes/fiber.go.tmpl
+++ b/cmd/template/framework/files/routes/fiber.go.tmpl
@@ -13,6 +13,7 @@ import (
 
 func (s *FiberServer) RegisterFiberRoutes() {
 	s.App.Get("/", s.HelloWorldHandler)
+	s.App.Get("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	s.App.Get("/health", s.healthHandler)
   {{end}}
@@ -26,6 +27,14 @@ func (s *FiberServer) RegisterFiberRoutes() {
 func (s *FiberServer) HelloWorldHandler(c *fiber.Ctx) error {
 	resp := fiber.Map{
 		"message": "Hello World",
+	}
+
+	return c.JSON(resp)
+}
+
+func (s *FiberServer) statusHandler(c *fiber.Ctx) error {
+	resp := fiber.Map{
+		"status": "OK",
 	}
 
 	return c.JSON(resp)

--- a/cmd/template/framework/files/routes/gin.go.tmpl
+++ b/cmd/template/framework/files/routes/gin.go.tmpl
@@ -17,6 +17,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r := gin.Default()
 
 	r.GET("/", s.HelloWorldHandler)
+	r.GET("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	r.GET("/health", s.healthHandler)
   {{end}}
@@ -71,3 +72,7 @@ func (s *Server) websocketHandler(c *gin.Context) {
 	}
 }
 {{end}}
+
+func (s *Server) statusHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "OK"})
+}

--- a/cmd/template/framework/files/routes/gorilla.go.tmpl
+++ b/cmd/template/framework/files/routes/gorilla.go.tmpl
@@ -17,6 +17,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/", s.HelloWorldHandler)
+	r.HandleFunc("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	r.HandleFunc("/health", s.healthHandler)
   {{end}}
@@ -32,6 +33,18 @@ func (s *Server) RegisterRoutes() http.Handler {
 func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 	resp := make(map[string]string)
 	resp["message"] = "Hello World"
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("error handling JSON marshal. Err: %v", err)
+	}
+
+	_, _ = w.Write(jsonResp)
+}
+
+func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
+	resp := make(map[string]string)
+	resp["status"] = "OK"
 
 	jsonResp, err := json.Marshal(resp)
 	if err != nil {

--- a/cmd/template/framework/files/routes/http_router.go.tmpl
+++ b/cmd/template/framework/files/routes/http_router.go.tmpl
@@ -16,6 +16,7 @@ import (
 func (s *Server) RegisterRoutes() http.Handler {
 	r := httprouter.New()
 	r.HandlerFunc(http.MethodGet, "/", s.HelloWorldHandler)
+	r.HandlerFunc(http.MethodGet,"/status", s.statusHandler)
 
   {{if ne .DBDriver "none"}}
 	r.HandlerFunc(http.MethodGet, "/health", s.healthHandler)
@@ -31,6 +32,18 @@ func (s *Server) RegisterRoutes() http.Handler {
 func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 	resp := make(map[string]string)
 	resp["message"] = "Hello World"
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("error handling JSON marshal. Err: %v", err)
+	}
+
+	_, _ = w.Write(jsonResp)
+}
+
+func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
+	resp := make(map[string]string)
+	resp["status"] = "OK"
 
 	jsonResp, err := json.Marshal(resp)
 	if err != nil {

--- a/cmd/template/framework/files/routes/standard_library.go.tmpl
+++ b/cmd/template/framework/files/routes/standard_library.go.tmpl
@@ -16,6 +16,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.HelloWorldHandler)
+    mux.HandleFunc("/status", s.statusHandler)
   {{if ne .DBDriver "none"}}
 	mux.HandleFunc("/health", s.healthHandler)
   {{end}}
@@ -30,6 +31,19 @@ func (s *Server) RegisterRoutes() http.Handler {
 func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 	resp := make(map[string]string)
 	resp["message"] = "Hello World"
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		log.Fatalf("error handling JSON marshal. Err: %v", err)
+	}
+
+	_, _ = w.Write(jsonResp)
+}
+
+
+func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
+	resp := make(map[string]string)
+	resp["status"] = "OK"
 
 	jsonResp, err := json.Marshal(resp)
 	if err != nil {

--- a/docs/docs/endpoints-test/server.md
+++ b/docs/docs/endpoints-test/server.md
@@ -25,6 +25,21 @@ Sample Output:
 If the server is running and it is healthy, you should see the message 'Hello World' in the response.
 Also, depending on the framework you are using, there will be logs in the terminal:
 
+## Status Endpoint
+
+To test the Status endpoint, execute the following curl command:
+
+```bash
+curl http://localhost:PORT/status
+```
+
+Sample Output:
+```json
+{"status": "OK"}
+```
+If the server is running and it is healthy, you should see the status 'OK' in the response.
+Also, depending on the framework you are using, there will be logs in the terminal:
+
 ```bash
 make run
 [GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

'/status' route required for health check of api's
## Description of Changes: 

- added a '/status' endpoint GET type  for each framework
- added a handler function for each framework response return { status: "OK" }.

## Checklist

- [ ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
